### PR TITLE
Fix #8: Don't crash on a node-gpsd error

### DIFF
--- a/gpsd/gpsd.js
+++ b/gpsd/gpsd.js
@@ -98,6 +98,10 @@ module.exports = function(RED) {
 		// Do whatever you need to do in here - declare callbacks etc
 		
 		node.listener = new node_gpsd.Listener(settings) ;
+		
+		node.listener.on('error', function(param) {
+			node.error(param)
+		});
 
 		// Register specific listener for TPV events (location) and check the
 		// mode property to see if we have a fix


### PR DESCRIPTION
Hardens the node to handle 'error' events from node-gpsd, which would otherwise cause the Node runtime to quit.